### PR TITLE
Set rank as the first order of VEP

### DIFF
--- a/cwas/core/annotation/vep.py
+++ b/cwas/core/annotation/vep.py
@@ -92,7 +92,7 @@ class VepCmdGenerator:
             "--per_gene",
             "--pick",
             "--pick_order",
-            "canonical,appris,tsl,biotype,ccds,rank,length",
+            "rank,canonical,appris,tsl,biotype,ccds,length",
         ]
 
     @property


### PR DESCRIPTION
The order of VEP --pick_order is now rank,canonical,appris,tsl,biotype,ccds,length